### PR TITLE
Specify orgmgmt-proto as application dependency

### DIFF
--- a/src/bouncer.app.src
+++ b/src/bouncer.app.src
@@ -13,6 +13,7 @@
         gun,
         jesse,
         bouncer_proto,
+        org_management_proto,
         erl_health
     ]},
     {env, []},


### PR DESCRIPTION
Otherwise it's missing from a release.