### PR TITLE
fix: Add thrift encoding for boolean values

### DIFF
--- a/src/bouncer_thrift.erl
+++ b/src/bouncer_thrift.erl
@@ -85,6 +85,8 @@ to_thrift_value(i32, V, _NameFun) ->
 to_thrift_value(i16, V, _NameFun) ->
     V;
 to_thrift_value(byte, V, _NameFun) ->
+    V;
+to_thrift_value(bool, V, _NameFun) ->
     V.
 
 from_thrift_struct(StructDef, Struct) ->
@@ -120,6 +122,8 @@ from_thrift_value(i32, V) ->
 from_thrift_value(i16, V) ->
     V;
 from_thrift_value(byte, V) ->
+    V;
+from_thrift_value(bool, V) ->
     V.
 
 identity(V) ->


### PR DESCRIPTION
См. https://mon.rbkmoney.com/kibana/app/discover#/doc/7d175040-16ab-11ea-85a4-bd2eccef0f8d/filebeat-2021.08.04-09.12?id=vYU3EHsBEo9cB1iOKjre

Note: пытался диалайзер натравить на это, но видимо нет non-exhaustiveness check 🤷 